### PR TITLE
only require 2 command line args, not 3

### DIFF
--- a/bin/tradis_gene_insert_sites
+++ b/bin/tradis_gene_insert_sites
@@ -87,7 +87,7 @@ $trim5 ||= 0;
 $trim3 ||= 0;
 
 ( !$help
-  && scalar( @ARGV ) > 2
+  && scalar( @ARGV ) >= 2
   && $trim5 >= 0 && $trim5 < 1
   && $trim3 >= 0 && $trim3 < 1 ) or die $usage;
 


### PR DESCRIPTION
This was preventing the standard command-line usage "tradis_gene_insert_sites my_annotation.embl my_insert_site_plot.gz" and returning the help screen instead. I'm not sure why this check was here, so hopefully I haven't broken anything else in fixing this.