### PR TITLE
Ticket 473325: Install two different versions of SAMTOOLS

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -6,9 +6,13 @@ set -e
 start_dir=$(pwd)
 
 SMALT_VERSION="0.7.6"
+HERITAGE_SAMTOOLS_VERSION="0.1.19"
+TABIX_VERSION="master"
 SAMTOOLS_VERSION="1.2"
 
 SMALT_DOWNLOAD_URL="http://downloads.sourceforge.net/project/smalt/smalt-${SMALT_VERSION}-bin.tar.gz"
+HERITAGE_SAMTOOLS_DOWNLOAD_URL="https://github.com/samtools/samtools/archive/${HERITAGE_SAMTOOLS_VERSION}.tar.gz"
+TABIX_DOWNLOAD_URL="https://github.com/samtools/tabix/archive/${TABIX_VERSION}.tar.gz"
 SAMTOOLS_DOWNLOAD_URL="https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2"
 
 # Make an install location
@@ -32,6 +36,8 @@ download () {
 }
 
 download $SMALT_DOWNLOAD_URL "smalt-${SMALT_VERSION}.tgz"
+download $HERITAGE_SAMTOOLS_DOWNLOAD_URL "heritage_samtools-${HERITAGE_SAMTOOLS_VERSION}.tgz"
+download $TABIX_DOWNLOAD_URL "tabix-${TABIX_VERSION}.tgz"
 download $SAMTOOLS_DOWNLOAD_URL "samtools-${SAMTOOLS_VERSION}.tbz"
 
 # Update dependencies
@@ -54,6 +60,37 @@ if [ ! -e "$smalt_dir/smalt" ]; then
   ln "$smalt_dir/smalt_x86_64" "$smalt_dir/smalt" 
 fi
 
+## heritage_samtools
+cd $build_dir
+heritage_samtools_dir=$(pwd)/"samtools-$HERITAGE_SAMTOOLS_VERSION"
+if [ ! -d $heritage_samtools_dir ]; then
+  tar xzfv "${build_dir}/heritage_samtools-${HERITAGE_SAMTOOLS_VERSION}.tgz"
+fi
+cd $heritage_samtools_dir
+if [ -e ${heritage_samtools_dir}/samtools ]; then
+  echo "Already built heritage samtools"
+else
+  echo "Building heritage samtools"
+  sed -i 's/^\(DFLAGS=.\+\)-D_CURSES_LIB=1/\1-D_CURSES_LIB=0/' Makefile
+  sed -i 's/^\(LIBCURSES=\)/#\1/' Makefile
+  make CFLAGS=-fPIC
+fi
+export SAMTOOLS=${heritage_samtools_dir}
+
+## tabix
+cd $build_dir
+tabix_dir=$(pwd)/"tabix-$TABIX_VERSION"
+if [ ! -d $tabix_dir ]; then
+  tar xzfv "${build_dir}/tabix-${TABIX_VERSION}.tgz"
+fi
+cd $tabix_dir
+if [ -e ${tabix_dir}/tabix ]; then
+  echo "Already built tabix"
+else
+  echo "Building tabix"
+  make
+fi
+
 ## samtools
 cd $build_dir
 samtools_dir=$(pwd)/"samtools-$SAMTOOLS_VERSION"
@@ -61,16 +98,14 @@ if [ ! -d $samtools_dir ]; then
   tar xjfv "${build_dir}/samtools-${SAMTOOLS_VERSION}.tbz"
 fi
 cd $samtools_dir
-if [ -e ${samtools_dir}/bin/samtools ]; then
+if [ -e ${samtools_dir}/samtools ]; then
   echo "Already built samtools"
 else
   echo "Building samtools"
   sed -i 's/^\(DFLAGS=.\+\)-D_CURSES_LIB=1/\1-D_CURSES_LIB=0/' Makefile
   sed -i 's/^\(LIBCURSES=\)/#\1/' Makefile
-  make prefix=$samtools_dir install
-  ln -s ${samtools_dir}/bin/samtools ${samtools_dir}/bin/samtools-htslib
+  make prefix=${samtools_dir} install
 fi
-export SAMTOOLS=${samtools_dir}
 
 # Setup environment variables
 update_path () {
@@ -81,19 +116,9 @@ update_path () {
 }
 
 update_path ${smalt_dir}
-update_path "${samtools_dir}/bin"
-
-update_cpath () {
-  new_dir=$1
-  export CPATH=${CPATH:-$new_dir}
-  if [[ ! "$CPATH" =~ (^|:)"${new_dir}"(:|$) ]]; then
-    export CPATH=${new_dir}:${CPATH}
-  fi
-}
-
-htslib_path=$(find $samtools_dir -maxdepth 1 -type d -name htslib*)
-update_cpath ${htslib_path}
-update_cpath ${htslib_path}/htslib
+update_path "${heritage_samtools_dir}"
+update_path "${tabix_dir}"
+update_path "${samtools_dir}"
 
 cd $start_dir
 


### PR DESCRIPTION
Bio::DB::Sam needs old style Samtools (<1.0) while Bio::Tradis::Parser
needs a version which can parse CRAM files.

The tests should now pass but I can't help but wonder if Bio::DB::Sam
could find itself asked to do something with a CRAM file...

I'll have a look in another PR