### PR TITLE
Added support for samtools 1.x, -n multi-core option and fixed -m default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Objects and Methods
 	* `mappedfile` - mapped and sorted BAM file
 * Optional parameters:
 	* `outfile` - base name to assign to the resulting insertion site plot. Default = tradis.plot
-	* `mapping_score` - cutoff value for mapping score. Default = 30
+	* `mapping_score` - cutoff value for mapping score. Default = 0
 * Methods:
 	* `plot` - create insertion site plots for reads in `mappedfile`. This file will be readable by the Artemis genome browser (http://www.sanger.ac.uk/resources/software/artemis/)
 	 
@@ -131,7 +131,7 @@ Objects and Methods
 * Optional parameters:
 	* `mismatch` - number of mismatches to allow when filtering/removing the tag. Default = 0
 	* `tagdirection` - direction of the tag, 5' or 3'. Default = 3
-	* `mapping_score` - cutoff value for mapping score. Default = 30
+	* `mapping_score` - cutoff value for mapping score. Default = 0
 * Methods:
 	* `run_tradis` - run complete analysis
 

--- a/lib/Bio/Tradis/CommandLine/PlotTradis.pm
+++ b/lib/Bio/Tradis/CommandLine/PlotTradis.pm
@@ -17,7 +17,7 @@ use Bio::Tradis::TradisPlot;
 has 'args'        => ( is => 'ro', isa => 'ArrayRef', required => 1 );
 has 'script_name' => ( is => 'ro', isa => 'Str',      required => 1 );
 has 'mappedfile'  => ( is => 'rw', isa => 'Str',      required => 0 );
-has 'mapping_score' => ( is => 'rw', isa => 'Int', required => 0, default => 30);
+has 'mapping_score' => ( is => 'rw', isa => 'Int', required => 0, default => 0);
 has 'help'        => ( is => 'rw', isa => 'Bool',     required => 0 );
 has 'outfile'     => ( is => 'rw', isa => 'Str',      required => 0, default => 'tradis.plot' );
 
@@ -67,7 +67,7 @@ Usage: tradis_plot -f file.bam [options]
 
 Options:
 -f  : mapped, sorted bam file
--m	: mapping quality must be greater than X (optional. default: 30)
+-m	: mapping quality must be greater than X (optional. default: 0)
 -o  : output base name for plot (optional. default: tradis.plot)
 
 USAGE

--- a/lib/Bio/Tradis/CommandLine/RunMapping.pm
+++ b/lib/Bio/Tradis/CommandLine/RunMapping.pm
@@ -27,6 +27,7 @@ has 'smalt_k' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_s' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_y' => ( is => 'rw', isa => 'Maybe[Num]', required => 0, default => 0.96 );
 has 'smalt_r' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => -1 );
+has 'smalt_n' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => 1 );
 
 sub BUILD {
     my ($self) = @_;
@@ -43,6 +44,7 @@ sub BUILD {
 	'ss|smalt_s=i'    => \$smalt_s,
 	'sy|smalt_y=f'    => \$smalt_y,
 	'sr|smalt_r=i'    => \$smalt_r,
+	'n|sn|smalt_r=i'  => \$smalt_n,
         'h|help'          => \$help
     );
 
@@ -54,6 +56,7 @@ sub BUILD {
     $self->smalt_s( $smalt_s )               if ( defined($smalt_s) );
     $self->smalt_y( $smalt_y )               if ( defined($smalt_y) );
     $self->smalt_r( $smalt_r )               if ( defined($smalt_r) );
+    $self->smalt_n( $smalt_n )               if ( defined($smalt_n) );
     $self->help($help)                       if ( defined($help) );
 
 	# print usage text if required parameters are not present
@@ -104,6 +107,7 @@ Options:
 --smalt_k : custom k-mer value for SMALT mapping
 --smalt_s : custom step size for SMALT mapping
 --smalt_r : custom r value for SMALT mapping
+--smalt_n : custom n value for SMALT mapping
 
 USAGE
       exit;

--- a/lib/Bio/Tradis/CommandLine/TradisAnalysis.pm
+++ b/lib/Bio/Tradis/CommandLine/TradisAnalysis.pm
@@ -25,11 +25,12 @@ has 'tagdirection' =>
 has 'reference' => ( is => 'rw', isa => 'Str',  required => 0 );
 has 'help'      => ( is => 'rw', isa => 'Bool', required => 0 );
 has 'mapping_score' =>
-  ( is => 'rw', isa => 'Int', required => 0, default => 30 );
+  ( is => 'rw', isa => 'Int', required => 0, default => 0 );
 has 'smalt_k' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_s' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_y' => ( is => 'rw', isa => 'Maybe[Num]', required => 0, default => 0.96 );
 has 'smalt_r' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => -1 );
+has 'smalt_n' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => 1 );
 
 has 'verbose' => ( is => 'rw', isa => 'Bool', default => 0 );
 has 'samtools_exec' => ( is => 'rw', isa => 'Str', default => 'samtools' );
@@ -55,7 +56,7 @@ sub BUILD {
 
     my (
         $fastqfile, $tag,     $td,      $mismatch, $ref,
-        $map_score, $smalt_k, $smalt_s, $smalt_y, $smalt_r, $help, $verbose,$samtools_exec
+        $map_score, $smalt_k, $smalt_s, $smalt_y, $smalt_r, $smalt_n, $help, $verbose,$samtools_exec
     );
 
     GetOptionsFromArray(
@@ -70,6 +71,7 @@ sub BUILD {
         'ss|smalt_s=i'      => \$smalt_s,
         'sy|smalt_y=f'      => \$smalt_y,
 	'sr|smalt_r=i'      => \$smalt_r,
+	'n|smalt_n=i'       => \$smalt_n,
         'v|verbose'         => \$verbose,
         'samtools_exec=s'   => \$samtools_exec,
         'h|help'            => \$help
@@ -85,6 +87,7 @@ sub BUILD {
     $self->smalt_s($smalt_s)                 if ( defined($smalt_s) );
     $self->smalt_y($smalt_y)                 if ( defined($smalt_y) );
     $self->smalt_r($smalt_r)		     if ( defined($smalt_r) );
+    $self->smalt_n($smalt_n)		     if ( defined($smalt_n) );
     $self->help($help)                       if ( defined($help) );
     $self->verbose($verbose)                 if ( defined($verbose));
     $self->samtools_exec($samtools_exec)     if ( defined($samtools_exec) );
@@ -141,6 +144,7 @@ sub run {
             smalt_s          => $self->smalt_s,
             smalt_y          => $self->smalt_y,
             smalt_r          => $self->smalt_r,
+            smalt_n          => $self->smalt_n,
             verbose          => $self->verbose,
             samtools_exec    => $self->samtools_exec
         );
@@ -241,11 +245,12 @@ Options:
 -r        : reference genome in fasta format (.fa)
 -td       : tag direction - 3 or 5 (optional. default = 3)
 -mm       : number of mismatches allowed when matching tag (optional. default = 0)
--m        : mapping quality cutoff score (optional. default = 30)
+-m        : mapping quality cutoff score (optional. default = 0)
 --smalt_k : custom k-mer value for SMALT mapping (optional)
 --smalt_s : custom step size for SMALT mapping (optional)
 --smalt_y : custom y parameter for SMALT (optional. default = 0.96)
 --smalt_r : custom r parameter for SMALT (optional. default = -1)
+-n        : number of threads to use for SMALT and samtools sort (optional. default = 1)
 -v        : verbose debugging output
 USAGE
     exit;

--- a/lib/Bio/Tradis/Map.pm
+++ b/lib/Bio/Tradis/Map.pm
@@ -76,6 +76,7 @@ has 'smalt_k' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_s' => ( is => 'rw', isa => 'Maybe[Int]', required => 0 );
 has 'smalt_y' => ( is => 'rw', isa => 'Maybe[Num]', required => 0, default => 0.96 );
 has 'smalt_r' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => -1 );
+has 'smalt_n' => ( is => 'rw', isa => 'Maybe[Int]', required => 0, default => 1 );
 
 sub index_ref {
     my ($self)  = @_;
@@ -127,8 +128,9 @@ sub do_mapping {
     my $outfile = $self->outfile;
     my $y = $self->smalt_y;
     my $r = $self->smalt_r;
+    my $n = $self->smalt_n;
 
-    my $smalt = "smalt map -x -r $r -y $y $refname $fqfile 1> $outfile  2> smalt.stderr";
+    my $smalt = "smalt map -n $n -x -r $r -y $y $refname $fqfile 1> $outfile  2> smalt.stderr";
 
     system($smalt);
     unlink('smalt.stderr');


### PR DESCRIPTION
Added support for samtools 1.x (older versions will still work)

Added -n option to allow use of multiple cores for SMALT and samtools sort

Changed the default for -m from 30 to 0. Filtering on mapping quality can have unintended consequences for TraDIS analysis, as it effectively removes ambiguously-mapped reads from the analysis, meaning that repeat regions of the genome can be incorrectly identified as essential.