### PR TITLE
modified ranges to accommodate higher density insertion data

### DIFF
--- a/bin/tradis_essentiality.R
+++ b/bin/tradis_essentiality.R
@@ -21,25 +21,25 @@ STM_baseline <- read.table(input, sep="\t",header=TRUE,stringsAsFactors=F, quote
 ii <- STM_baseline$ins_index
 
 #identify second maxima
-h <- hist(ii, breaks=100,plot=FALSE)
-maxindex <- which.max(h$density[3:length(h$density)])
-maxval <- h$mids[maxindex+2]
+h <- hist(ii, breaks=200,plot=FALSE)
+maxindex <- which.max(h$density[10:length(h$density)])
+maxval <- h$mids[maxindex+3]
 
 # print pdf of loess curve and later on, histogram
 pdf(paste(input, "QC_and_changepoint_plots", "pdf", sep = "."))
 
 #find inter-mode minima with loess
 nG <- length(STM_baseline$read_count)
-r <- floor(maxval *1000)
-I = ii < r / 1000
-h1 = hist(ii[I],breaks=(0:r/1000))
+r <- floor(maxval *2000)
+I = ii < r / 2000
+h1 = hist(ii[I],breaks=(0:r/2000))
 lo <- loess(h1$density ~ c(1:length(h1$density))) #loess smothing over density
 plot(h1$density, main="Density")
 lines(predict(lo),col='red',lwd=2)
 m = h1$mids[which.min(predict(lo))]
 I1 = ((ii < m)&(ii >= 0))
 
-h = hist(ii, breaks=100,plot=FALSE) 
+h = hist(ii, breaks="FD",plot=FALSE) 
 I2 = ((ii >= m)&(ii < h$mids[max(which(h$counts>5))]))
 f1 = (sum(I1) + sum(ii == 0))/nG
 f2 = (sum(I2))/nG
@@ -51,14 +51,14 @@ d2 = fitdistr(ii[I2], "gamma") #fit curves
 #pdf("Loess_and_changepoint_estimation.pdf")
 
 #plots
-hist(ii,breaks=200, xlim=c(0,0.1), freq=FALSE,xlab="Insertion index", main="Gamma fits")
-lines(0:50/500, f1*dgamma(0:50/500, 1, d1$estimate[1])) # was [2]
-lines(0:50/500, f2*dgamma(0:50/500, d2$estimate[1], d2$estimate[2]))
+hist(ii,breaks="FD", xlim=c(0,max(ii)), freq=FALSE,xlab="Insertion index", main="Gamma fits")
+lines(0:200/500, f1*dgamma(0:200/500, 1, d1$estimate[1])) # was [2]
+lines(0:200/500, f2*dgamma(0:200/500, d2$estimate[1], d2$estimate[2]))
 # print changepoint
 
 #calculate log-odds ratios to choose thresholds
-lower <- max(which(log((pgamma(1:500/10000, d2$e[1],d2$e[2])*(1-pgamma(1:500/10000, 1,d1$e[1], lower.tail=FALSE)))/(pgamma(1:500/10000, 1,d1$e[1], lower.tail=FALSE)*(1-pgamma(1:500/10000, d2$e[1],d2$e[2]))) , base=2) < -2))
-upper <- min(which(log((pgamma(1:500/10000, d2$e[1],d2$e[2])*(1-pgamma(1:500/10000, 1,d1$e[1], lower.tail=FALSE)))/(pgamma(1:500/10000, 1,d1$e[1], lower.tail=FALSE)*(1-pgamma(1:500/10000, d2$e[1],d2$e[2]))) , base=2) > 2))
+lower <- max(which(log((pgamma(1:1000/10000, d2$e[1],d2$e[2])*(1-pgamma(1:1000/10000, 1,d1$e[1], lower.tail=FALSE)))/(pgamma(1:1000/10000, 1,d1$e[1], lower.tail=FALSE)*(1-pgamma(1:1000/10000, d2$e[1],d2$e[2]))) , base=2) < -2))
+upper <- min(which(log((pgamma(1:1000/10000, d2$e[1],d2$e[2])*(1-pgamma(1:1000/10000, 1,d1$e[1], lower.tail=FALSE)))/(pgamma(1:1000/10000, 1,d1$e[1], lower.tail=FALSE)*(1-pgamma(1:1000/10000, d2$e[1],d2$e[2]))) , base=2) > 2))
 
 essen <- lower/10000
 ambig <- upper/10000


### PR DESCRIPTION
I've just made some minor modifications that allow tradis_essentiality.R to work with higher density data, after running into a problem with a particular data set, basically because I had set the ranges to be too small. I have tested in on our old Salmonella data, and seems to still work there as well.