### PR TITLE
include last base of annotation in insertion count

### DIFF
--- a/bin/tradis_gene_insert_sites
+++ b/bin/tradis_gene_insert_sites
@@ -132,7 +132,7 @@ for my $insert_sites ( @ins_list ){
 
         my $count = 0;
         my $inserts = 0;
-        for(my $j=$read_start;$j < $read_end; $j++){
+        for(my $j=$read_start;$j <= $read_end; $j++){
             $count += $insert_sites->[$j];
             $inserts += 1 if $insert_sites->[$j] > 0;
         }


### PR DESCRIPTION
This fixes issue #81 , where @ppgardne observed insertion indices never goes to 1 in an artificial experiment with tiled reads -- the last base of genome annotations was being unintentionally excluded from read count sums, due to use of a < rather than <= to. This is unlikely to have serious effects on real data, as it only affected insertions in the last base of an annotation (or trimmed annotation with the -trim flags), and all processed libraries would be affected in the same way.