### PR TITLE
Fix missing library

### DIFF
--- a/bin/bacteria_tradis
+++ b/bin/bacteria_tradis
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::RunTradis;
+use FindBin qw($Bin);
 
 # ABSTRACT: Perform full tradis analysis
 # PODNAME: run_tradis
@@ -15,6 +16,7 @@ site plots for use in Artemis
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib") }
 
 use Bio::Tradis::CommandLine::TradisAnalysis;
 


### PR DESCRIPTION
When running the script from a working directory different that its binary dir, it will not find the library Bio::Tradis::...
Added FindBin to resolve the issue