### PR TITLE
Fixed relative path to ./lib problem in binaries using FindBin

### DIFF
--- a/.travis.nosudo
+++ b/.travis.nosudo
@@ -1,0 +1,23 @@
+language: perl
+addons:
+  apt:
+    packages:
+    - zlib1g-dev
+    - libgd-gd2-perl
+    - libxml-libxml-perl
+    - bioperl
+    - libncurses5-dev 
+    - libncursesw5-dev
+perl:
+  - "5.14"
+  - "5.22"
+sudo: false
+install:
+  - "source ./install_dependencies.sh"
+before_script:
+  - cpanm --force Dist::Zilla::Plugin::Test::Compile
+  - cpanm --quiet --notest Dist::Zilla::App::Command::cover
+  - cpanm --quiet --notest --skip-satisfied Devel::Cover::Report::Codecov
+script: "dzil test"
+after_success:
+  - dzil cover -test -report codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ addons:
     - zlib1g-dev
     - libgd-perl
     - libgd-dev
+    - libgd-gd2-perl
     - libxml-libxml-perl
+    - bioperl
     - libncurses5-dev 
     - libncursesw5-dev
 perl:
-  - "5.18"
+  - "5.14"
   - "5.22"
 sudo: false
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ addons:
   apt:
     packages:
     - zlib1g-dev
-    - libgd-perl
-    - libgd-dev
     - libgd-gd2-perl
     - libxml-libxml-perl
     - bioperl

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ addons:
   apt:
     packages:
     - zlib1g-dev
+    - libgd-perl
+    - libgd-dev
+    - libncurses5-dev 
+    - libncursesw5-dev
 perl:
   - "5.18"
   - "5.22"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,10 @@
-language: perl
-addons:
-  apt:
-    packages:
-    - zlib1g-dev
-    - libgd-gd2-perl
-    - libxml-libxml-perl
-    - bioperl
-    - libncurses5-dev 
-    - libncursesw5-dev
-perl:
-  - "5.14"
-  - "5.22"
-sudo: false
+sudo: required
+services:
+  - docker
 install:
-  - "source ./install_dependencies.sh"
-before_script:
-  - cpanm --force Dist::Zilla::Plugin::Test::Compile
-  - cpanm --quiet --notest Dist::Zilla::App::Command::cover
-  - cpanm --quiet --notest --skip-satisfied Devel::Cover::Report::Codecov
-script: "dzil test"
-after_success:
-  - dzil cover -test -report codecov
+  - docker pull andreatelatin/biotradis
+script:
+  - docker run --rm -it andratelatin/biotradis /bin/sh -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && bash 
+install_dependencies.sh && dzil test"
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ sudo: false
 install:
   - "source ./install_dependencies.sh"
 before_script:
+  - cpanm --force Dist::Zilla::Plugin::Test::Compile
   - cpanm --quiet --notest Dist::Zilla::App::Command::cover
   - cpanm --quiet --notest --skip-satisfied Devel::Cover::Report::Codecov
 script: "dzil test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     - zlib1g-dev
     - libgd-perl
     - libgd-dev
+    - libxml-libxml-perl
     - libncurses5-dev 
     - libncursesw5-dev
 perl:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ services:
 install:
   - docker pull andreatelatin/biotradis
 script:
-  - docker run --rm -it andratelatin/biotradis /bin/bash -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
+  - docker run --rm -it andreatelatin/biotradis /bin/bash -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 install:
   - docker pull andreatelatin/biotradis
 script:
-  - docker run --rm -it andratelatin/biotradis /bin/sh -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && bash 
-install_dependencies.sh && dzil test"
+  - docker run --rm -it andratelatin/biotradis /bin/bash -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ addons:
     packages:
     - zlib1g-dev
 perl:
-  - "5.14"
+  - "5.18"
+  - "5.22"
 sudo: false
 install:
   - "source ./install_dependencies.sh"

--- a/bin/add_tradis_tags
+++ b/bin/add_tradis_tags
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::DetectTags;
+use FindBin qw($Bin); 
 
 # ABSTRACT: check if tr tag is present
 # PODNAME: check_tags
@@ -14,6 +15,7 @@ Checks the presence of tr/tq tags in a given BAM file
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::AddTags;
 

--- a/bin/bacteria_tradis
+++ b/bin/bacteria_tradis
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::RunTradis;
+use FindBin qw($Bin); 
 
 # ABSTRACT: Perform full tradis analysis
 # PODNAME: run_tradis
@@ -15,6 +16,7 @@ site plots for use in Artemis
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::TradisAnalysis;
 

--- a/bin/check_tradis_tags
+++ b/bin/check_tradis_tags
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::DetectTags;
+use FindBin qw($Bin); 
 
 # ABSTRACT: check if tr tag is present
 # PODNAME: check_tags
@@ -14,6 +15,7 @@ Checks the presence of tr/tq tags in a given BAM file
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::CheckTags;
 

--- a/bin/combine_tradis_plots
+++ b/bin/combine_tradis_plots
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::CombineTradisPlots;
+use FindBin qw($Bin); 
 
 # ABSTRACT: Combine multiple plotfiles and generate updated statistics for the combined files
 
@@ -17,6 +18,7 @@ plotfile and as an identifier in the stats file, so ensure these are unique.
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::PlotCombine;
 

--- a/bin/filter_tradis_tags
+++ b/bin/filter_tradis_tags
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::FilterTags;
+use FindBin qw($Bin); 
 
 # ABSTRACT: filter tags at start of fastq sequences
 # PODNAME: filter_tags
@@ -15,6 +16,7 @@ match the tag provided
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::FilterFastqTags;
 

--- a/bin/remove_tradis_tags
+++ b/bin/remove_tradis_tags
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::RemoveTags;
+use FindBin qw($Bin); 
 
 # ABSTRACT: remove user specified tags from start of fastq sequences
 # PODNAME: remove_tags
@@ -14,6 +15,7 @@ Removes tags from the sequence and quality strings based on user input
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::RemoveFastqTags;
 

--- a/bin/tradis_gene_insert_sites
+++ b/bin/tradis_gene_insert_sites
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::GeneInsertSites;
+use FindBin qw($Bin); 
 
 # ABSTRACT: Generate insertion site details from TraDIS pipeline plots
 

--- a/bin/tradis_merge_plots
+++ b/bin/tradis_merge_plots
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::MergePlots;
+use FindBin qw($Bin); 
 
 # ABSTRACT: 
 

--- a/bin/tradis_plot
+++ b/bin/tradis_plot
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 package Bio::Tradis::Bin::TradisPlot;
+use FindBin qw($Bin); 
 
 # ABSTRACT: Generate plots as part of a tradis analysis
 # PODNAME: tradis_plot
@@ -15,6 +16,7 @@ a reference in GFF format
 BEGIN { unshift( @INC, '../lib' ) }
 BEGIN { unshift( @INC, './lib' ) }
 BEGIN { unshift( @INC, '/software/pathogen/internal/prod/lib/' ) }
+BEGIN { unshift( @INC, "$Bin/../lib/" ) }
 
 use Bio::Tradis::CommandLine::PlotTradis;
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS" = 'true' ]; then
   echo "Using Travis's apt plugin"
 else
   sudo apt-get update -q
-  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev libxml-libxml-perl 
+  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev libxml-libxml-perl libgd-gd2-perl bioperl
 fi
 
 # Build all the things

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS" = 'true' ]; then
   echo "Using Travis's apt plugin"
 else
   sudo apt-get update -q
-  sudo apt-get install -y -q zlib1g-dev
+  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev
 fi
 
 # Build all the things

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -118,6 +118,10 @@ cd $start_dir
 
 # Install perl dependencies
 cpanm Dist::Zilla
+
+# Patch? 
+cpanm --force Dist::Zilla::PluginBundle::Starter
+
 dzil authordeps --missing | cpanm
 dzil listdeps --missing | cpanm
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,7 +45,8 @@ if [ "$TRAVIS" = 'true' ]; then
   echo "Using Travis's apt plugin"
 else
   sudo apt-get update -q
-  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev libxml-libxml-perl libgd-gd2-perl bioperl
+  sudo apt-get install -y -q zlib1g-dev libxml-libxml-perl libgd-gd2-perl bioperl 
+  #libgd-perl libgd-dev 
 fi
 
 # Build all the things

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS" = 'true' ]; then
   echo "Using Travis's apt plugin"
 else
   sudo apt-get update -q
-  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev
+  sudo apt-get install -y -q zlib1g-dev libgd-perl libgd-dev libxml-libxml-perl 
 fi
 
 # Build all the things

--- a/source_path
+++ b/source_path
@@ -1,0 +1,24 @@
+start_dir=$(pwd)
+
+SMALT_VERSION="0.7.6"
+BWA_VERSION="0.7.17"
+TABIX_VERSION="master"
+SAMTOOLS_VERSION="1.3"
+
+smalt_dir=$(pwd)/"smalt-${SMALT_VERSION}-bin"
+bwa_dir=$(pwd)/"bwa-${BWA_VERSION}"
+tabix_dir=$(pwd)/"tabix-$TABIX_VERSION"
+samtools_dir=$(pwd)/"samtools-$SAMTOOLS_VERSION"
+
+update_path () {
+  new_dir=$1
+  if [[ ! "$PATH" =~ (^|:)"${new_dir}"(:|$) ]]; then
+    export PATH=${new_dir}:${PATH}
+  fi
+}
+
+update_path ${smalt_dir}
+update_path ${bwa_dir}
+update_path "${tabix_dir}"
+update_path "${samtools_dir}"
+


### PR DESCRIPTION
In all executable scripts, this was added:
```perl
use FindBin qw($Bin);
BEGIN { unshift( @INC, "$Bin/../lib/" ) }
```
to allow to find library module with a path relative to the binary itself (when invoked from elsewhere)