### PR TITLE
Update TravisCI tests using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ services:
 install:
   - docker pull andreatelatin/biotradis
 script:
-  - docker run --rm -it andreatelatin/biotradis /bin/bash -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
+  - docker run --rm -it andreatelatin/biotradis /bin/bash -c "git clone https://github.com/sanger-pathogens/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,9 @@
-language: perl
-addons:
-  apt:
-    packages:
-    - zlib1g-dev
-perl:
-  - "5.14"
-sudo: false
+sudo: required
+services:
+  - docker
 install:
-  - "source ./install_dependencies.sh"
-before_script:
-  - cpanm --quiet --notest Dist::Zilla::App::Command::cover
-  - cpanm --quiet --notest --skip-satisfied Devel::Cover::Report::Codecov
-script: "dzil test"
-after_success:
-  - dzil cover -test -report codecov
+  - docker pull andreatelatin/biotradis
+script:
+  - docker run --rm -it andreatelatin/biotradis /bin/bash -c "git clone https://github.com/telatin/Bio-Tradis.git && cd Bio-Tradis && source ./install_dependencies.sh && dzil test"
+
+

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,7 +45,8 @@ if [ "$TRAVIS" = 'true' ]; then
   echo "Using Travis's apt plugin"
 else
   sudo apt-get update -q
-  sudo apt-get install -y -q zlib1g-dev
+  sudo apt-get install -y -q zlib1g-dev libxml-libxml-perl libgd-gd2-perl bioperl 
+  #libgd-perl libgd-dev 
 fi
 
 # Build all the things
@@ -118,6 +119,10 @@ cd $start_dir
 
 # Install perl dependencies
 cpanm Dist::Zilla
+
+# Patch? 
+cpanm --force Dist::Zilla::PluginBundle::Starter
+
 dzil authordeps --missing | cpanm
 dzil listdeps --missing | cpanm
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -46,7 +46,6 @@ if [ "$TRAVIS" = 'true' ]; then
 else
   sudo apt-get update -q
   sudo apt-get install -y -q zlib1g-dev libxml-libxml-perl libgd-gd2-perl bioperl 
-  #libgd-perl libgd-dev 
 fi
 
 # Build all the things
@@ -120,7 +119,7 @@ cd $start_dir
 # Install perl dependencies
 cpanm Dist::Zilla
 
-# Patch? 
+# Patch fo install Dist::Zilla::PluginBundle::Starter
 cpanm --force Dist::Zilla::PluginBundle::Starter
 
 dzil authordeps --missing | cpanm

--- a/source_path
+++ b/source_path
@@ -1,0 +1,24 @@
+start_dir=$(pwd)
+
+SMALT_VERSION="0.7.6"
+BWA_VERSION="0.7.17"
+TABIX_VERSION="master"
+SAMTOOLS_VERSION="1.3"
+
+smalt_dir=$(pwd)/"smalt-${SMALT_VERSION}-bin"
+bwa_dir=$(pwd)/"bwa-${BWA_VERSION}"
+tabix_dir=$(pwd)/"tabix-$TABIX_VERSION"
+samtools_dir=$(pwd)/"samtools-$SAMTOOLS_VERSION"
+
+update_path () {
+  new_dir=$1
+  if [[ ! "$PATH" =~ (^|:)"${new_dir}"(:|$) ]]; then
+    export PATH=${new_dir}:${PATH}
+  fi
+}
+
+update_path ${smalt_dir}
+update_path ${bwa_dir}
+update_path "${tabix_dir}"
+update_path "${samtools_dir}"
+

--- a/source_path
+++ b/source_path
@@ -1,5 +1,3 @@
-start_dir=$(pwd)
-
 SMALT_VERSION="0.7.6"
 BWA_VERSION="0.7.17"
 TABIX_VERSION="master"


### PR DESCRIPTION
(1) Using a docker container with Ubuntu and required packages:

- Dockerfile: https://github.com/telatin/docker-files/tree/master/biotradis

And (2) updating .travis.yml and install_dependencies.sh:

- https://github.com/telatin/Bio-Tradis/blob/master/.travis.yml (using Docker)
- https://github.com/telatin/Bio-Tradis/blob/master/install_dependencies.sh (forcing _Dist::Zilla::PluginBundle::Starter_, that  atmo cannot be installed without problems in a vanilla Ubuntu container. )

...resulted in **test passed** (commit 41af008).

_Note:_ Now I updated _.travis.yml_ to get the repository from sanger rather than my fork (to prepare this pull request), thus the test is currently failing as the install_dependencies.sh script is still to be patched.