### PR TITLE
Removed '--force' for [@Starter]

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -118,9 +118,7 @@ cd $start_dir
 
 # Install perl dependencies
 cpanm Dist::Zilla
-
-# Patch fo install Dist::Zilla::PluginBundle::Starter
-cpanm --force Dist::Zilla::PluginBundle::Starter
+cpanm Dist::Zilla::PluginBundle::Starter
 
 dzil authordeps --missing | cpanm
 dzil listdeps --missing | cpanm


### PR DESCRIPTION
Install Dist::Zilla::PluginBundle::Starter was forced to ignore a failing test. The problem was fixed with release v3.0.3  (2019-05-19 12:12:06 EDT)