### PR TITLE
add locales to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,17 @@
 FROM debian:bullseye-slim
 
 # Install the dependancies
-RUN apt-get update -qq && apt-get install -y sudo make wget unzip zlib1g-dev cpanminus gcc bzip2 libncurses5-dev libncursesw5-dev libssl-dev r-base git libxml-libxml-perl libgd-gd2-perl bioperl bwa smalt tabix samtools
+RUN apt-get update -qq && apt-get install -y sudo make wget unzip zlib1g-dev cpanminus gcc bzip2 libncurses5-dev libncursesw5-dev libssl-dev r-base git libxml-libxml-perl libgd-gd2-perl bioperl bwa smalt tabix samtools locales
 RUN wget https://github.com/lh3/minimap2/releases/download/v2.17/minimap2-2.17_x64-linux.tar.bz2
 RUN tar xjfv minimap2-2.17_x64-linux.tar.bz2
+
+# Set locales (required for running in Singularity)
+RUN   sed -i -e 's/# \(en_GB\.UTF-8 .*\)/\1/' /etc/locale.gen && \
+      touch /usr/share/locale/locale.alias && \
+      locale-gen
+ENV   LANG     en_GB.UTF-8
+ENV   LANGUAGE en_GB:en
+ENV   LC_ALL   en_GB.UTF-8
 
 # Install R dependencies
 RUN Rscript -e "install.packages('BiocManager')" -e "BiocManager::install()" -e "BiocManager::install(c('edgeR','getopt', 'MASS'))"


### PR DESCRIPTION
This is necessary for running the Docker image in Singularity, which otherwise can't determine the encoding and will cause trouble for any non-ascii input.